### PR TITLE
Fix Javascript error in theme stemming from update to jQuery 4

### DIFF
--- a/src/js/airtable-list-builder.js
+++ b/src/js/airtable-list-builder.js
@@ -2,6 +2,9 @@
   Drupal.behaviors.airtableListBuilder = {
     attach: function (context, settings) {
 
+      // Need to shim the trim function for jQuery 4. Chosen needs it.
+      if (typeof jQuery.trim === 'undefined') { jQuery.trim = function(text) { return text == null ? '' : String.prototype.trim.call(text); }; }
+
       // Get the content area
       var $contentArea = $("#airtable-list");
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- An error was occurring because .trim function was removed from jQuery 4. We have an old library called chosen that still uses that function. We have added a shim to fix this issue. 

# Review By (Date)
- ASAP

# Criticality
- Needs to be done before the migration to Drupal 11 moves to production.

# Urgency
- Normal

# Review Tasks

